### PR TITLE
Improvements to QUIC parsing for QUIC Fingerprint

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1.0.96"
 strum = "0.20"
 strum_macros = "0.20"
 thiserror = "1.0"
-tls-parser = { git = "https://github.com/stanford-esrg/tls-parser" }
+tls-parser = { git = "https://github.com/sippejw/tls-parser", branch = "qtp" }
 toml = "0.5.11"
 x509-parser = "0.13.2"
 bitmask-enum = "2.2.4"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,6 +31,7 @@ log = { version = "0.4", features = ["release_max_level_info"] }
 maplit = "1.0.2"
 md5 = "0.7.0"
 nom = "7.1.3"
+num_enum = "0.7.3"
 pcap = "0.8.1"
 pest = "2.5.7"
 pest_derive = "2.5"

--- a/core/src/protocols/stream/quic/crypto.rs
+++ b/core/src/protocols/stream/quic/crypto.rs
@@ -157,6 +157,19 @@ impl Open {
         self.hp_key.algorithm().sample_len()
     }
 }
+
+impl Clone for Open {
+    fn clone(&self) -> Self {
+        Open {
+            alg: self.alg,
+            initial_key: self.initial_key.clone(),
+            hp_key: aead::quic::HeaderProtectionKey::new(self.alg.get_ring_hp(), &self.initial_key)
+                .expect("Failed to clone hp_key"),
+            iv: self.iv.clone(),
+        }
+    }
+}
+
 impl std::fmt::Debug for Open {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Point")

--- a/core/src/protocols/stream/quic/frame.rs
+++ b/core/src/protocols/stream/quic/frame.rs
@@ -78,10 +78,9 @@ impl QuicFrame {
     // it also returns the reassembled CRYPTO frame bytes as a Vec<u8>
     pub fn parse_frames(
         data: &[u8],
-        mut expected_offset: usize,
-    ) -> Result<(Vec<QuicFrame>, Vec<u8>), QuicError> {
+        crypto_map: &mut BTreeMap<usize, Vec<u8>>,
+    ) -> Result<Vec<QuicFrame>, QuicError> {
         let mut frames: Vec<QuicFrame> = Vec::new();
-        let mut crypto_map: BTreeMap<usize, Vec<u8>> = BTreeMap::new();
         let mut offset = 0;
         // Iterate over plaintext payload bytes, this is a list of frames
         while offset < data.len() {
@@ -257,14 +256,6 @@ impl QuicFrame {
                 _ => return Err(QuicError::UnknownFrameType),
             }
         }
-        let mut reassembled_crypto: Vec<u8> = Vec::new();
-        for (crypto_offset, crypto_data) in crypto_map {
-            if crypto_offset != expected_offset {
-                return Err(QuicError::MissingCryptoFrames);
-            }
-            expected_offset += crypto_data.len();
-            reassembled_crypto.extend(crypto_data);
-        }
-        Ok((frames, reassembled_crypto))
+        Ok(frames)
     }
 }

--- a/core/src/protocols/stream/quic/frame.rs
+++ b/core/src/protocols/stream/quic/frame.rs
@@ -1,11 +1,27 @@
 // QUIC Frame types and parsing
 // Implemented per RFC 9000: https://datatracker.ietf.org/doc/html/rfc9000#name-frame-types-and-formats
 
+use num_enum::TryFromPrimitive;
 use serde::Serialize;
+
 use std::collections::BTreeMap;
 
 use crate::protocols::stream::quic::QuicError;
 use crate::protocols::stream::quic::QuicPacket;
+
+// QUIC Frame IDs, used to identify frame types as defined by RFC 9000 Section 19
+// https://datatracker.ietf.org/doc/html/rfc9000#name-frame-types-and-formats
+#[derive(Clone, Debug, Serialize, TryFromPrimitive)]
+#[repr(u64)]
+pub enum QuicFrameId {
+    Padding = 0x00,
+    Ping = 0x01,
+    Ack = 0x02,
+    AckEcn = 0x03,
+    ResetStream = 0x04,
+    StopSending = 0x05,
+    Crypto = 0x06,
+}
 
 // Types of supported QUIC frames
 // Currently only includes those seen in the Init and Handshake packets
@@ -25,6 +41,19 @@ pub enum QuicFrame {
     Crypto {
         offset: u64,
     },
+}
+
+impl QuicFrame {
+    // Returns the frame type ID as a u8
+    // Used for serialization and frame identification
+    pub fn get_frame_type(&self) -> u8 {
+        match self {
+            QuicFrame::Padding { .. } => QuicFrameId::Padding as u8,
+            QuicFrame::Ping => QuicFrameId::Ping as u8,
+            QuicFrame::Ack { .. } => QuicFrameId::Ack as u8,
+            QuicFrame::Crypto { .. } => QuicFrameId::Crypto as u8,
+        }
+    }
 }
 
 // ACK Range field, part of ACK frame
@@ -65,8 +94,8 @@ impl QuicFrame {
                 offset + frame_type_len,
             )?)?;
             offset += frame_type_len;
-            match frame_type {
-                0x00 => {
+            match QuicFrameId::try_from(frame_type) {
+                Ok(QuicFrameId::Padding) => {
                     // Handle PADDING
                     let mut length = 0;
                     while offset + length + 1 < data.len()
@@ -79,11 +108,11 @@ impl QuicFrame {
                     length += frame_type_len; // Add the original frame type bytes to length. Wireshark also does this
                     frames.push(QuicFrame::Padding { length });
                 }
-                0x01 => {
+                Ok(QuicFrameId::Ping) => {
                     // Handle PING
                     frames.push(QuicFrame::Ping);
                 }
-                0x02 | 0x03 => {
+                Ok(QuicFrameId::Ack) | Ok(QuicFrameId::AckEcn) => {
                     // Handle ACK
                     // Parse Largest Acknowledged
                     let largest_acknowledged_len = QuicPacket::get_var_len(
@@ -192,7 +221,7 @@ impl QuicFrame {
                         ecn_counts,
                     })
                 }
-                0x06 => {
+                Ok(QuicFrameId::Crypto) => {
                     // Handle CRYPTO frame
                     // Parse offset
                     let crypto_offset_len = QuicPacket::get_var_len(

--- a/core/src/protocols/stream/quic/mod.rs
+++ b/core/src/protocols/stream/quic/mod.rs
@@ -162,3 +162,9 @@ impl QuicPacket {
         self.payload_bytes_count.unwrap_or_default()
     }
 }
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct QuicTransportParameter {
+    pub parameter_id: u64,
+    pub parameter: Vec<u8>,
+}

--- a/core/src/protocols/stream/quic/mod.rs
+++ b/core/src/protocols/stream/quic/mod.rs
@@ -20,20 +20,23 @@ TODO: support parsing the tls out of the initial quic packet setup
 TODO support dns over quic
 TODO: support HTTP/3
 */
-pub(crate) mod parser;
+use serde::Serialize;
 
 use std::collections::HashSet;
 
-pub use self::header::{QuicLongHeader, QuicShortHeader};
-use crypto::Open;
-use frame::QuicFrame;
-use header::LongHeaderPacketType;
-use serde::Serialize;
-
-use super::tls::Tls;
 pub(crate) mod crypto;
 pub(crate) mod frame;
 pub(crate) mod header;
+pub(crate) mod parser;
+pub(crate) mod qtp;
+
+pub use self::header::{QuicLongHeader, QuicShortHeader};
+pub use self::qtp::{QuicTransportParameters, TransportParameter};
+pub use frame::QuicFrame;
+
+use super::tls::Tls;
+use crypto::Open;
+use header::LongHeaderPacketType;
 
 /// Errors Thrown throughout QUIC parsing. These are handled by retina and used to skip packets.
 #[derive(Debug)]
@@ -91,6 +94,12 @@ pub struct QuicPacket {
 
     /// The number of bytes contained in the estimated payload
     pub payload_bytes_count: Option<u64>,
+
+    // length of the packet number in bytes
+    pub packet_number_length: Option<u8>,
+
+    // packet number converted to u32 (max size of packet number)
+    pub packet_number: Option<u32>,
 
     pub frames: Option<Vec<QuicFrame>>,
 }
@@ -161,10 +170,4 @@ impl QuicPacket {
     pub fn payload_bytes_count(&self) -> u64 {
         self.payload_bytes_count.unwrap_or_default()
     }
-}
-
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct QuicTransportParameter {
-    pub parameter_id: u64,
-    pub parameter: Vec<u8>,
 }

--- a/core/src/protocols/stream/quic/mod.rs
+++ b/core/src/protocols/stream/quic/mod.rs
@@ -57,7 +57,7 @@ pub enum QuicError {
 }
 
 /// Parsed Quic connections
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct QuicConn {
     // All packets associated with the connection
     pub packets: Vec<QuicPacket>,
@@ -84,7 +84,7 @@ pub struct QuicConn {
 }
 
 /// Parsed Quic Packet contents
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct QuicPacket {
     /// Quic Short header
     pub short_header: Option<QuicShortHeader>,

--- a/core/src/protocols/stream/quic/mod.rs
+++ b/core/src/protocols/stream/quic/mod.rs
@@ -22,7 +22,7 @@ TODO: support HTTP/3
 */
 use serde::Serialize;
 
-use std::collections::HashSet;
+use std::collections::{HashSet, BTreeMap};
 
 pub(crate) mod crypto;
 pub(crate) mod frame;
@@ -76,9 +76,15 @@ pub struct QuicConn {
 
     // Client buffer for multi-packet TLS messages
     #[serde(skip_serializing)]
+    pub client_map: BTreeMap<usize, Vec<u8>>,
+
+    #[serde(skip_serializing)]
     pub client_buffer: Vec<u8>,
 
     // Server buffer for multi-packet TLS messages
+    #[serde(skip_serializing)]
+    pub server_map: BTreeMap<usize, Vec<u8>>,
+
     #[serde(skip_serializing)]
     pub server_buffer: Vec<u8>,
 }

--- a/core/src/protocols/stream/quic/parser.rs
+++ b/core/src/protocols/stream/quic/parser.rs
@@ -13,7 +13,7 @@ use crate::protocols::stream::{
     ConnParsable, L4Pdu, ParseResult, ParsingState, ProbeResult, Session, SessionData,
 };
 use byteorder::{BigEndian, ByteOrder};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use tls_parser::parse_tls_message_handshake;
 
 use super::QuicConn;
@@ -394,30 +394,41 @@ impl QuicPacket {
 
             let mut frames: Option<Vec<QuicFrame>> = None;
             // Grab the proper buffer for CRYPTO frame data
-            let crypto_buffer: &mut Vec<u8> = if dir {
-                conn.client_buffer.as_mut()
+            let (crypto_map, crypto_buffer): (&mut BTreeMap<usize, Vec<u8>>, &mut Vec<u8>) = if dir {
+                (&mut conn.client_map, &mut conn.client_buffer)
             } else {
-                conn.server_buffer.as_mut()
+                (&mut conn.server_map, &mut conn.server_buffer)
             };
             // If decrypted payload is not None, parse the frames
             if let Some(frame_bytes) = decrypted_payload {
                 // Get frames and reassembled CRYPTO data
                 // Pass the buffer's current length as starting offset for CRYPTO frames
-                let (q_frames, mut crypto_bytes) =
-                    QuicFrame::parse_frames(&frame_bytes, crypto_buffer.len())?;
+                let q_frames =
+                    QuicFrame::parse_frames(&frame_bytes, crypto_map)?;
                 frames = Some(q_frames);
-                if !crypto_bytes.is_empty() {
-                    crypto_buffer.append(&mut crypto_bytes);
+                if !crypto_map.is_empty() {
+                    // Reassemble CRYPTO frames into a single buffer
+                    // let mut reassembled_crypto: Vec<u8> = Vec::new();
+                    let mut expected_offset = crypto_buffer.len();
+                    let mut to_remove = Vec::new();
+                    for (crypto_offset, crypto_data) in crypto_map.iter() {
+                        if *crypto_offset != expected_offset {
+                            break;
+                        }
+                        expected_offset += crypto_data.len();
+                        crypto_buffer.extend_from_slice(crypto_data);
+                        to_remove.push(*crypto_offset);
+                    }
+                    for offset in to_remove {
+                        crypto_map.remove(&offset);
+                    }
                     // Attempt to parse CRYPTO buffer
                     // clear on success
-                    // TODO: This naive buffer will not work for out of order frames
-                    // across packets or multiple messages in the same buffer
-                    match parse_tls_message_handshake(crypto_buffer) {
-                        Ok((_, msg)) => {
-                            conn.tls.parse_message_level(&msg, dir);
-                            crypto_buffer.clear();
-                        }
-                        Err(_) => return Err(QuicError::TlsParseFail),
+                    if let Ok((_, msg)) = parse_tls_message_handshake(crypto_buffer)
+                    {
+                        conn.tls.parse_message_level(&msg, dir);
+                        crypto_buffer.clear();
+                        crypto_map.clear();
                     }
                 }
             }
@@ -490,7 +501,9 @@ impl QuicConn {
             tls: Tls::new(),
             client_opener: None,
             server_opener: None,
+            client_map: BTreeMap::new(),
             client_buffer: Vec::new(),
+            server_map: BTreeMap::new(),
             server_buffer: Vec::new(),
         }
     }

--- a/core/src/protocols/stream/quic/parser.rs
+++ b/core/src/protocols/stream/quic/parser.rs
@@ -237,11 +237,14 @@ impl QuicPacket {
             }
             offset += scid_len as usize;
 
+            // Initialize variables for packet type specific fields
             let token_len;
             let token;
             let packet_len;
             let retry_tag;
             let decrypted_payload;
+            let packet_number_length;
+            let packet_number;
             // Parse packet type specific fields
             match packet_type {
                 LongHeaderPacketType::Initial => {
@@ -291,15 +294,16 @@ impl QuicPacket {
                     }
                     // Parse packet number
                     let packet_num_len = ((unprotected_header & 0b00000011) + 1) as usize;
+                    packet_number_length = Some(packet_num_len as u8);
                     let packet_number_bytes =
                         QuicPacket::access_data(data, offset, offset + packet_num_len)?;
-                    let mut packet_number = vec![0; 4 - packet_num_len];
+                    let mut packet_number_calc = vec![0; 4 - packet_num_len];
                     for i in 0..packet_num_len {
-                        packet_number.push(packet_number_bytes[i] ^ mask[i + 1]);
+                        packet_number_calc.push(packet_number_bytes[i] ^ mask[i + 1]);
                     }
-
-                    let initial_packet_number_bytes = &packet_number[4 - packet_num_len..];
-                    let packet_number_int = BigEndian::read_i32(&packet_number);
+                    let initial_packet_number_bytes = &packet_number_calc[4 - packet_num_len..];
+                    let packet_number_int = BigEndian::read_i32(&packet_number_calc);
+                    packet_number = Some(packet_number_int as u32);
                     offset += packet_num_len;
                     // Parse the encrypted payload
                     let tag_len = conn.client_opener.as_ref().unwrap().alg().tag_len();
@@ -349,6 +353,8 @@ impl QuicPacket {
                     token = None;
                     retry_tag = None;
                     decrypted_payload = None;
+                    packet_number_length = None;
+                    packet_number = None;
                     // Parse payload length
                     let packet_len_len = QuicPacket::get_var_len(
                         QuicPacket::access_data(data, offset, offset + 1)?[0],
@@ -364,6 +370,8 @@ impl QuicPacket {
                 LongHeaderPacketType::Retry => {
                     packet_len = None;
                     decrypted_payload = None;
+                    packet_number_length = None;
+                    packet_number = None;
                     if data.len() > (offset + 16) {
                         token_len = Some((data.len() - offset - 16) as u64);
                     } else {
@@ -431,6 +439,8 @@ impl QuicPacket {
                         retry_tag,
                     }),
                     frames,
+                    packet_number_length,
+                    packet_number,
                 },
                 offset,
             ))
@@ -463,6 +473,8 @@ impl QuicPacket {
                     long_header: None,
                     payload_bytes_count: Some(payload_bytes_count),
                     frames: None,
+                    packet_number_length: None,
+                    packet_number: None,
                 },
                 offset,
             ))

--- a/core/src/protocols/stream/quic/parser.rs
+++ b/core/src/protocols/stream/quic/parser.rs
@@ -75,12 +75,14 @@ impl ConnParsable for QuicParser {
                 }
 
                 // Check if version is known
+                // An unknown version must be handled as
+                // a potential QUIC packet due to Version Negotiation
                 let version = ((data[1] as u32) << 24)
                     | ((data[2] as u32) << 16)
                     | ((data[3] as u32) << 8)
                     | (data[4] as u32);
                 match QuicVersion::from_u32(version) {
-                    QuicVersion::Unknown => ProbeResult::NotForUs,
+                    QuicVersion::Unknown => ProbeResult::Unsure,
                     _ => ProbeResult::Certain,
                 }
             } else {

--- a/core/src/protocols/stream/quic/qtp.rs
+++ b/core/src/protocols/stream/quic/qtp.rs
@@ -11,7 +11,7 @@ fn var_int(i: &[u8]) -> (u64, &[u8]) {
     let length = 1 << prefix;
     v &= 0x3f;
     for &j in i.iter().take(length).skip(1) {
-        v = (v << 8) | i[j as usize] as u64;
+        v = (v << 8) | j as u64;
     }
     (v, &i[length..])
 }

--- a/core/src/protocols/stream/quic/qtp.rs
+++ b/core/src/protocols/stream/quic/qtp.rs
@@ -1,0 +1,364 @@
+use num_enum::TryFromPrimitive;
+use serde::Serialize;
+
+use std::cmp::Ordering;
+
+// Helper function to decode variable-length integers as defined in RFC 9000 Section 16
+// https://www.rfc-editor.org/rfc/rfc9000#name-variable-length-integer-enc
+fn var_int(i: &[u8]) -> (u64, &[u8]) {
+    let mut v: u64 = i[0] as u64;
+    let prefix = v >> 6;
+    let length = 1 << prefix;
+    v &= 0x3f;
+    for &j in i.iter().take(length).skip(1) {
+        v = (v << 8) | i[j as usize] as u64;
+    }
+    (v, &i[length..])
+}
+
+// Check if a transport parameter ID is a reserved (GREASEd) value.
+// Defined by RFC 9000 Secion 18.1: https://www.rfc-editor.org/rfc/rfc9000#section-18.1
+pub fn is_reserved(parameter_id: u64) -> bool {
+    if parameter_id >= 27 {
+        return (parameter_id - 27) % 31 == 0;
+    }
+    false
+}
+
+// Original Transport Parameter IDs as defined by RFC 9000 Section 18.2: // https://www.rfc-editor.org/rfc/rfc9000#section-18.2
+// This could be expanded to include implementation specific parameters or future extensions.
+#[derive(Clone, Debug, Serialize, TryFromPrimitive)]
+#[repr(u64)]
+pub enum TransportParameterId {
+    OriginalDestinationConnectionId = 0x0000,
+    MaxIdleTimeout = 0x0001,
+    StatelessResetToken = 0x0002,
+    MaxUdpPayloadSize = 0x0003,
+    InitialMaxData = 0x0004,
+    InitialMaxStreamDataBidiLocal = 0x0005,
+    InitialMaxStreamDataBidiRemote = 0x0006,
+    InitialMaxStreamDataUni = 0x0007,
+    InitialMaxStreamsBidi = 0x0008,
+    InitialMaxStreamsUni = 0x0009,
+    AckDelayExponent = 0x000A,
+    MaxAckDelay = 0x000B,
+    DisableActiveMigration = 0x000C,
+    PreferredAddress = 0x000D,
+    ActiveConnectionIdLimit = 0x000E,
+    InitialSourceConnectionId = 0x000F,
+    RetrySourceConnectionId = 0x0010,
+    VersionInformation = 0x0011,
+    ParameterGrease = 0x001B,
+    MaxDatagramFrameSize = 0x0020,
+    GreaseQuicBit = 0x2AB2,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub enum TransportParameter {
+    OriginalDestinationConnectionId(Vec<u8>),
+    MaxIdleTimeout {
+        value: Vec<u8>,
+        max_idle_timeout: u64,
+    },
+    StatelessResetToken([u8; 16]),
+    MaxUdpPayloadSize {
+        value: Vec<u8>,
+        max_udp_payload_size: u64,
+    },
+    InitialMaxData {
+        value: Vec<u8>,
+        initial_max_data: u64,
+    },
+    InitialMaxStreamDataBidiLocal {
+        value: Vec<u8>,
+        initial_max_stream_data_bidi_local: u64,
+    },
+    InitialMaxStreamDataBidiRemote {
+        value: Vec<u8>,
+        initial_max_stream_data_bidi_remote: u64,
+    },
+    InitialMaxStreamDataUni {
+        value: Vec<u8>,
+        initial_max_stream_data_uni: u64,
+    },
+    InitialMaxStreamsBidi {
+        value: Vec<u8>,
+        initial_max_streams_bidi: u64,
+    },
+    InitialMaxStreamsUni {
+        value: Vec<u8>,
+        initial_max_streams_uni: u64,
+    },
+    AckDelayExponent {
+        value: Vec<u8>,
+        ack_delay_exponent: u64,
+    },
+    MaxAckDelay {
+        value: Vec<u8>,
+        max_ack_delay: u64,
+    },
+    DisableActiveMigration,
+    PreferredAddress {
+        ipv4_address: u32,
+        ipv4_port: u16,
+        ipv6_address: [u8; 16],
+        ipv6_port: u16,
+        connection_id: Vec<u8>,
+        stateless_reset_token: [u8; 16],
+    },
+    ActiveConnectionIdLimit {
+        value: Vec<u8>,
+        active_connection_id_limit: u64,
+    },
+    InitialSourceConnectionId(Vec<u8>),
+    RetrySourceConnectionId(Vec<u8>),
+    VersionInformation {
+        chosen_version: u32,
+        supported_versions: Vec<u32>,
+    },
+    ParameterGrease {
+        id: u64,
+        value: Vec<u8>,
+    },
+    MaxDatagramFrameSize {
+        value: Vec<u8>,
+        max_datagram_frame_size: u64,
+    },
+    GreaseQuicBit,
+    Unknown {
+        id: u64,
+        value: Vec<u8>,
+    },
+}
+
+impl TransportParameter {
+    // Returns the ID of the transport parameter as defined by RFC 9000 Section 18.2
+    pub fn get_id(&self) -> u64 {
+        match self {
+            TransportParameter::OriginalDestinationConnectionId { .. } => {
+                TransportParameterId::OriginalDestinationConnectionId as u64
+            }
+            TransportParameter::MaxIdleTimeout { .. } => {
+                TransportParameterId::MaxIdleTimeout as u64
+            }
+            TransportParameter::StatelessResetToken { .. } => {
+                TransportParameterId::StatelessResetToken as u64
+            }
+            TransportParameter::MaxUdpPayloadSize { .. } => {
+                TransportParameterId::MaxUdpPayloadSize as u64
+            }
+            TransportParameter::InitialMaxData { .. } => {
+                TransportParameterId::InitialMaxData as u64
+            }
+            TransportParameter::InitialMaxStreamDataBidiLocal { .. } => {
+                TransportParameterId::InitialMaxStreamDataBidiLocal as u64
+            }
+            TransportParameter::InitialMaxStreamDataBidiRemote { .. } => {
+                TransportParameterId::InitialMaxStreamDataBidiRemote as u64
+            }
+            TransportParameter::InitialMaxStreamDataUni { .. } => {
+                TransportParameterId::InitialMaxStreamDataUni as u64
+            }
+            TransportParameter::InitialMaxStreamsBidi { .. } => {
+                TransportParameterId::InitialMaxStreamsBidi as u64
+            }
+            TransportParameter::InitialMaxStreamsUni { .. } => {
+                TransportParameterId::InitialMaxStreamsUni as u64
+            }
+            TransportParameter::AckDelayExponent { .. } => {
+                TransportParameterId::AckDelayExponent as u64
+            }
+            TransportParameter::MaxAckDelay { .. } => TransportParameterId::MaxAckDelay as u64,
+            TransportParameter::DisableActiveMigration => {
+                TransportParameterId::DisableActiveMigration as u64
+            }
+            TransportParameter::PreferredAddress { .. } => {
+                TransportParameterId::PreferredAddress as u64
+            }
+            TransportParameter::ActiveConnectionIdLimit { .. } => {
+                TransportParameterId::ActiveConnectionIdLimit as u64
+            }
+            TransportParameter::InitialSourceConnectionId { .. } => {
+                TransportParameterId::InitialSourceConnectionId as u64
+            }
+            TransportParameter::RetrySourceConnectionId { .. } => {
+                TransportParameterId::RetrySourceConnectionId as u64
+            }
+            TransportParameter::VersionInformation { .. } => {
+                TransportParameterId::VersionInformation as u64
+            }
+            TransportParameter::MaxDatagramFrameSize { .. } => {
+                TransportParameterId::MaxDatagramFrameSize as u64
+            }
+            TransportParameter::GreaseQuicBit => TransportParameterId::GreaseQuicBit as u64,
+            TransportParameter::ParameterGrease { .. } => {
+                TransportParameterId::ParameterGrease as u64
+            }
+            TransportParameter::Unknown { id, .. } => *id,
+        }
+    }
+}
+
+impl PartialEq for TransportParameter {
+    fn eq(&self, other: &Self) -> bool {
+        self.get_id() == other.get_id()
+    }
+}
+
+impl Eq for TransportParameter {}
+
+impl PartialOrd for TransportParameter {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.get_id().cmp(&other.get_id()))
+    }
+}
+
+impl Ord for TransportParameter {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.get_id().cmp(&other.get_id())
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct QuicTransportParameters {
+    pub parameters: Vec<TransportParameter>,
+}
+
+impl QuicTransportParameters {
+    pub fn new(data: Vec<u8>) -> Self {
+        let mut parameters = Vec::new();
+        let mut data = data.as_slice();
+        while !data.is_empty() {
+            let (parameter_id, parameter_value, rest) = Self::parse_parameter(data);
+
+            let parameter = if is_reserved(parameter_id) {
+                TransportParameter::ParameterGrease {
+                    id: parameter_id,
+                    value: parameter_value.to_vec(),
+                }
+            } else {
+                match TransportParameterId::try_from(parameter_id) {
+                    Ok(TransportParameterId::OriginalDestinationConnectionId) => {
+                        TransportParameter::OriginalDestinationConnectionId(
+                            parameter_value.to_vec(),
+                        )
+                    }
+                    Ok(TransportParameterId::MaxIdleTimeout) => {
+                        TransportParameter::MaxIdleTimeout {
+                            value: parameter_value.to_vec(),
+                            max_idle_timeout: var_int(parameter_value).0,
+                        }
+                    }
+                    Ok(TransportParameterId::StatelessResetToken) => {
+                        TransportParameter::StatelessResetToken(parameter_value.try_into().unwrap())
+                    }
+                    Ok(TransportParameterId::MaxUdpPayloadSize) => {
+                        TransportParameter::MaxUdpPayloadSize {
+                            value: parameter_value.to_vec(),
+                            max_udp_payload_size: var_int(parameter_value).0,
+                        }
+                    }
+                    Ok(TransportParameterId::InitialMaxData) => {
+                        TransportParameter::InitialMaxData {
+                            value: parameter_value.to_vec(),
+                            initial_max_data: var_int(parameter_value).0,
+                        }
+                    }
+                    Ok(TransportParameterId::InitialMaxStreamDataBidiLocal) => {
+                        TransportParameter::InitialMaxStreamDataBidiLocal {
+                            value: parameter_value.to_vec(),
+                            initial_max_stream_data_bidi_local: var_int(parameter_value).0,
+                        }
+                    }
+                    Ok(TransportParameterId::InitialMaxStreamDataBidiRemote) => {
+                        TransportParameter::InitialMaxStreamDataBidiRemote {
+                            value: parameter_value.to_vec(),
+                            initial_max_stream_data_bidi_remote: var_int(parameter_value).0,
+                        }
+                    }
+                    Ok(TransportParameterId::InitialMaxStreamDataUni) => {
+                        TransportParameter::InitialMaxStreamDataUni {
+                            value: parameter_value.to_vec(),
+                            initial_max_stream_data_uni: var_int(parameter_value).0,
+                        }
+                    }
+                    Ok(TransportParameterId::InitialMaxStreamsBidi) => {
+                        TransportParameter::InitialMaxStreamsBidi {
+                            value: parameter_value.to_vec(),
+                            initial_max_streams_bidi: var_int(parameter_value).0,
+                        }
+                    }
+                    Ok(TransportParameterId::InitialMaxStreamsUni) => {
+                        TransportParameter::InitialMaxStreamsUni {
+                            value: parameter_value.to_vec(),
+                            initial_max_streams_uni: var_int(parameter_value).0,
+                        }
+                    }
+                    Ok(TransportParameterId::AckDelayExponent) => {
+                        TransportParameter::AckDelayExponent {
+                            value: parameter_value.to_vec(),
+                            ack_delay_exponent: var_int(parameter_value).0,
+                        }
+                    }
+                    Ok(TransportParameterId::MaxAckDelay) => TransportParameter::MaxAckDelay {
+                        value: parameter_value.to_vec(),
+                        max_ack_delay: var_int(parameter_value).0,
+                    },
+                    Ok(TransportParameterId::DisableActiveMigration) => {
+                        TransportParameter::DisableActiveMigration
+                    }
+                    Ok(TransportParameterId::PreferredAddress) => {
+                        todo!("Parse Preferred address")
+                    }
+                    Ok(TransportParameterId::ActiveConnectionIdLimit) => {
+                        TransportParameter::ActiveConnectionIdLimit {
+                            value: parameter_value.to_vec(),
+                            active_connection_id_limit: var_int(parameter_value).0,
+                        }
+                    }
+                    Ok(TransportParameterId::InitialSourceConnectionId) => {
+                        TransportParameter::InitialSourceConnectionId(parameter_value.to_vec())
+                    }
+                    Ok(TransportParameterId::RetrySourceConnectionId) => {
+                        TransportParameter::RetrySourceConnectionId(parameter_value.to_vec())
+                    }
+                    Ok(TransportParameterId::VersionInformation) => {
+                        todo!("Parse Version Information")
+                    }
+                    Ok(TransportParameterId::MaxDatagramFrameSize) => {
+                        TransportParameter::MaxDatagramFrameSize {
+                            value: parameter_value.to_vec(),
+                            max_datagram_frame_size: var_int(parameter_value).0,
+                        }
+                    }
+                    Ok(TransportParameterId::GreaseQuicBit) => TransportParameter::GreaseQuicBit,
+                    Ok(TransportParameterId::ParameterGrease) => {
+                        TransportParameter::ParameterGrease {
+                            id: parameter_id,
+                            value: parameter_value.to_vec(),
+                        }
+                    }
+                    Err(err) => {
+                        log::warn!("Failed to parse transport parameter: {:?}", err);
+                        TransportParameter::Unknown {
+                            id: parameter_id,
+                            value: parameter_value.to_vec(),
+                        }
+                    }
+                }
+            };
+            parameters.push(parameter);
+            data = rest;
+        }
+        QuicTransportParameters { parameters }
+    }
+
+    // Parses the parameter ID, parameter length, and parameter value(s) from the given data slice.
+    fn parse_parameter(data: &[u8]) -> (u64, &[u8], &[u8]) {
+        let (parameter_id, data) = var_int(data);
+        let (parameter_len, data) = var_int(data);
+        let parameter_value = &data[..parameter_len as usize];
+        let rest = &data[parameter_len as usize..];
+        (parameter_id, parameter_value, rest)
+    }
+}

--- a/core/src/protocols/stream/quic/qtp.rs
+++ b/core/src/protocols/stream/quic/qtp.rs
@@ -1,5 +1,5 @@
 use num_enum::TryFromPrimitive;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
 use std::cmp::Ordering;
 
@@ -53,7 +53,7 @@ pub enum TransportParameterId {
     GreaseQuicBit = 0x2AB2,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum TransportParameter {
     OriginalDestinationConnectionId(Vec<u8>),
     MaxIdleTimeout {
@@ -323,7 +323,17 @@ impl QuicTransportParameters {
                         TransportParameter::RetrySourceConnectionId(parameter_value.to_vec())
                     }
                     Ok(TransportParameterId::VersionInformation) => {
-                        todo!("Parse Version Information")
+                        TransportParameter::VersionInformation {
+                            chosen_version:  u32::from_be_bytes(
+                            parameter_value[0..4].try_into().expect("Invalid version length"),
+                        ),
+                            supported_versions: parameter_value[4..]
+                            .chunks(4)
+                            .map(|chunk| u32::from_be_bytes(
+                                chunk.try_into().expect("Invalid version length"),
+                            ))
+                            .collect::<Vec<u32>>(),
+                        }
                     }
                     Ok(TransportParameterId::MaxDatagramFrameSize) => {
                         TransportParameter::MaxDatagramFrameSize {

--- a/core/src/protocols/stream/tls/handshake.rs
+++ b/core/src/protocols/stream/tls/handshake.rs
@@ -27,6 +27,9 @@ pub struct ClientHello {
     pub signature_algs: Vec<SignatureScheme>,
     pub key_shares: Vec<KeyShareEntry>,
     pub supported_versions: Vec<TlsVersion>,
+    pub psk_exchange_modes: Vec<u8>,
+    pub compress_certificate: Vec<u8>,
+    pub record_size_limit: Option<u16>,
     pub quic_transport_parameters: Option<QuicTransportParameters>,
 }
 

--- a/core/src/protocols/stream/tls/handshake.rs
+++ b/core/src/protocols/stream/tls/handshake.rs
@@ -2,7 +2,7 @@
 //!
 //! See [tls-parser](https://docs.rs/tls-parser/latest/tls_parser/) for dependency type definitions.
 
-use crate::utils::base64;
+use crate::{protocols::stream::quic::QuicTransportParameter, utils::base64};
 
 use serde::Serialize;
 use tls_parser::{
@@ -27,6 +27,7 @@ pub struct ClientHello {
     pub signature_algs: Vec<SignatureScheme>,
     pub key_shares: Vec<KeyShareEntry>,
     pub supported_versions: Vec<TlsVersion>,
+    pub quic_transport_parameters: Vec<QuicTransportParameter>,
 }
 
 /// A parsed TLS ServerHello message.

--- a/core/src/protocols/stream/tls/handshake.rs
+++ b/core/src/protocols/stream/tls/handshake.rs
@@ -2,8 +2,8 @@
 //!
 //! See [tls-parser](https://docs.rs/tls-parser/latest/tls_parser/) for dependency type definitions.
 
-use crate::{protocols::stream::quic::QuicTransportParameter, utils::base64};
-
+use crate::protocols::stream::quic::qtp::QuicTransportParameters;
+use crate::utils::base64;
 use serde::Serialize;
 use tls_parser::{
     NamedGroup, SignatureScheme, TlsCipherSuiteID, TlsCompressionID, TlsExtensionType, TlsVersion,
@@ -27,7 +27,7 @@ pub struct ClientHello {
     pub signature_algs: Vec<SignatureScheme>,
     pub key_shares: Vec<KeyShareEntry>,
     pub supported_versions: Vec<TlsVersion>,
-    pub quic_transport_parameters: Vec<QuicTransportParameter>,
+    pub quic_transport_parameters: Option<QuicTransportParameters>,
 }
 
 /// A parsed TLS ServerHello message.

--- a/core/src/protocols/stream/tls/parser.rs
+++ b/core/src/protocols/stream/tls/parser.rs
@@ -15,10 +15,10 @@ use super::handshake::{
 };
 use super::Tls;
 use crate::conntrack::pdu::L4Pdu;
+use crate::protocols::stream::quic::qtp::QuicTransportParameters;
 use crate::protocols::stream::{
     ConnParsable, ParseResult, ParsingState, ProbeResult, Session, SessionData,
 };
-use crate::protocols::stream::quic::QuicTransportParameter;
 
 use tls_parser::*;
 
@@ -185,14 +185,9 @@ impl Tls {
                         TlsExtension::SupportedVersions(ref v) => {
                             client_hello.supported_versions = v.clone();
                         }
-                        TlsExtension::QuicTransportParameters(ref v) => {
-                            client_hello.quic_transport_parameters = v
-                                .iter()
-                                .map(|p| QuicTransportParameter {
-                                    parameter_id: p.id,
-                                    parameter: p.value.to_vec(),
-                                })
-                                .collect();
+                        TlsExtension::QuicTransportParameters(v) => {
+                            client_hello.quic_transport_parameters =
+                                Some(QuicTransportParameters::new(v.to_vec()));
                         }
                         _ => (),
                     }

--- a/core/src/protocols/stream/tls/parser.rs
+++ b/core/src/protocols/stream/tls/parser.rs
@@ -185,6 +185,15 @@ impl Tls {
                         TlsExtension::SupportedVersions(ref v) => {
                             client_hello.supported_versions = v.clone();
                         }
+                        TlsExtension::PskExchangeModes(ref v) => {
+                            client_hello.psk_exchange_modes = v.clone();
+                        }
+                        TlsExtension::CompressCertificate(v) => {
+                            client_hello.compress_certificate = v.to_vec();
+                        }
+                        TlsExtension::RecordSizeLimit(v) => {
+                            client_hello.record_size_limit = Some(v);
+                        }
                         TlsExtension::QuicTransportParameters(v) => {
                             client_hello.quic_transport_parameters =
                                 Some(QuicTransportParameters::new(v.to_vec()));

--- a/core/src/protocols/stream/tls/parser.rs
+++ b/core/src/protocols/stream/tls/parser.rs
@@ -18,6 +18,7 @@ use crate::conntrack::pdu::L4Pdu;
 use crate::protocols::stream::{
     ConnParsable, ParseResult, ParsingState, ProbeResult, Session, SessionData,
 };
+use crate::protocols::stream::quic::QuicTransportParameter;
 
 use tls_parser::*;
 
@@ -183,6 +184,15 @@ impl Tls {
                         }
                         TlsExtension::SupportedVersions(ref v) => {
                             client_hello.supported_versions = v.clone();
+                        }
+                        TlsExtension::QuicTransportParameters(ref v) => {
+                            client_hello.quic_transport_parameters = v
+                                .iter()
+                                .map(|p| QuicTransportParameter {
+                                    parameter_id: p.id,
+                                    parameter: p.value.to_vec(),
+                                })
+                                .collect();
                         }
                         _ => (),
                     }


### PR DESCRIPTION
# Description
This PR fixes a few bugs and makes improvements needed for QUIC fingerprinting.

# Changes
- Fix bugs in reassembly and adds support for multi-packet
- Move QTP parsing into `core/src/protocols/stream/quic/qtp.rs`
- Add support for some additional TLS extensions

# Notes
The `tls-parser` dependency has been changed from `https://github.com/stanford-esrg/tls-parser` to `https://github.com/sippejw/tls-parser` on the `qtp` branch to support the changes to QTP parsing.